### PR TITLE
Add support for launching external cmd.exe

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ is converted to:
 For more information about it, visit:
 https://devblogs.microsoft.com/commandline/share-environment-vars-between-wsl-and-windows
 
+#### external
+
+If `true`, then an external cmd.exe window will spawn with the command.
+
+> **Note**
+> 
+>  No output will be displayed in Sublime, therefore you cannot capture errors with `file_regex`, etc.
+
 ##### Example Build System to run file in WSL:
 
 ```json


### PR DESCRIPTION
Hey @deathaxe! Thanks for this plugin, have been using it for a few weeks now (with WSL1, even though you specifically only mention WSL2). The only functionality I've been wanting is for some long jobs to be displayed concurrently while shorter one off jobs are run at the same time. Because Sublime will just replace the output in the panel with the last job, and you can only kill the last job my workflow becomes suboptimal. My solution to this is to add a new optional param `"external"` which if true will spawn a cmd.exe window.

Please consider merging this in if you agree this belongs in the plugin like this. Happy to take feedback on the implementation and naming as well if you are interested.